### PR TITLE
Refactor: 장바구니 수량 0으로 시작하는 숫자 입력 제한, 반품/교환 신청완료 시 갱신되는 주문상태 값 수정

### DIFF
--- a/src/main/java/com/roommake/order/service/MyOrderService.java
+++ b/src/main/java/com/roommake/order/service/MyOrderService.java
@@ -6,7 +6,6 @@ import com.roommake.order.dto.MyOrderCriteria;
 import com.roommake.order.dto.OrderListDto;
 import com.roommake.order.dto.UserOrderInfoDto;
 import com.roommake.order.mapper.MyOrderMapper;
-import com.roommake.order.mapper.OrderMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,6 @@ import java.util.List;
 public class MyOrderService {
 
     private final MyOrderMapper myOrderMapper;
-    private final OrderMapper orderMapper;
 
     /**
      * 로그인한 유저의 모든 주문내역을 반환한다.

--- a/src/main/java/com/roommake/order/service/OrderClaimService.java
+++ b/src/main/java/com/roommake/order/service/OrderClaimService.java
@@ -155,7 +155,7 @@ public class OrderClaimService {
         if (form.getType().equals("return")) {
             // 반품처리
             orderClaimMapper.createItemReturn(form);
-            int statusId = 7;
+            int statusId = 6;
             orderClaimMapper.updateClaimOrderItemStatus(form.getOrderItemId(), statusId);
         } else {
             // 교환처리
@@ -190,7 +190,7 @@ public class OrderClaimService {
             orderClaimMapper.createExchangeDetail(exchangeDetail);
 
             // 3. 주문상세 상태 갱신
-            int statusId = 9;
+            int statusId = 8;
             orderClaimMapper.updateClaimOrderItemStatus(form.getOrderItemId(), statusId);
         }
     }

--- a/src/main/java/com/roommake/order/service/OrderService.java
+++ b/src/main/java/com/roommake/order/service/OrderService.java
@@ -8,7 +8,6 @@ import com.roommake.order.dto.OrderCreateForm;
 import com.roommake.order.dto.OrderDto;
 import com.roommake.order.dto.OrderItemDto;
 import com.roommake.order.mapper.DeliveryMapper;
-import com.roommake.order.mapper.MyOrderMapper;
 import com.roommake.order.mapper.OrderMapper;
 import com.roommake.order.vo.Delivery;
 import com.roommake.order.vo.Order;
@@ -45,7 +44,6 @@ public class OrderService {
     private final MailService mailService;
     private final UserMapper userMapper;
     private final CartMapper cartMapper;
-    private final MyOrderMapper myOrderMapper;
 
     /**
      * 장바구니에 담긴 상품의 정보를 반환한다.

--- a/src/main/resources/templates/cart/cart.html
+++ b/src/main/resources/templates/cart/cart.html
@@ -369,7 +369,7 @@
         // 빈 문자열이나 0 입력 시 알림
         $("button[id^=btn-update-amount-]").click(function() {
             let inputVal = $("input[id^=amount-]").val();
-            if (inputVal === "" || inputVal === "0") {
+            if (inputVal === "" || /^0+$/.test(inputVal)) {
                 alert("수량을 입력해주세요.");
                 return false;
             }
@@ -511,7 +511,7 @@
     // 주문하기로 상품번호, 상품상세번호, 상품수량 값 넘기기
     $("#btn-order").click(function() {
         let inputVal = $("input[id^=amount-]").val();
-        if (inputVal === "" || inputVal === "0") {
+        if (inputVal === "" || /^0+$/.test(inputVal)) {
             alert("수량을 입력해주세요.");
             return false;
         }


### PR DESCRIPTION
- 0 입력만 제한되어 있고 00, 000, 0000... 등은 입력 가능했던 기존 코드 수정
- 반품/교환 신청완료 시, 주문상세의 주문상태가 '반품/교환완료'로 갱신되었던 기존 코드를 '반품/교환신청'으로 갱신되도록 수정
- etc. 사용하지 않는 Mapper 주입 제거